### PR TITLE
Update tsconfig files

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,6 +9,7 @@ parserOptions:
 extends:
   - eslint:recommended
 rules:
+  consistent-return: error
   indent:
     - error
     - 4

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,6 @@
 plugins:
   - "@typescript-eslint"
+  - testing-library
 env:
   browser: true
   node: true
@@ -8,6 +9,7 @@ parserOptions:
   sourceType: module
 extends:
   - eslint:recommended
+  - plugin:testing-library/dom
 rules:
   consistent-return: error
   indent:

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "typescript": "~4.3.5"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12.13.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {

--- a/src/AccessTokenEvents.ts
+++ b/src/AccessTokenEvents.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Log, Timer } from "./utils";
-import { User } from "./User";
+import type { User } from "./User";
 
 export type AccessTokenCallback = (...ev: any[]) => void;
 

--- a/src/MetadataService.ts
+++ b/src/MetadataService.ts
@@ -3,8 +3,8 @@
 
 import { Log } from "./utils";
 import { JsonService } from "./JsonService";
-import { OidcClientSettingsStore } from "./OidcClientSettings";
-import { OidcMetadata } from "./OidcMetadata";
+import type { OidcClientSettingsStore } from "./OidcClientSettings";
+import type { OidcMetadata } from "./OidcMetadata";
 
 const OidcMetadataUrlPath = ".well-known/openid-configuration";
 

--- a/src/OidcClientSettings.ts
+++ b/src/OidcClientSettings.ts
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { WebStorageStateStore } from "./WebStorageStateStore";
-import { OidcMetadata } from "./OidcMetadata";
-import { StateStore } from "./StateStore";
+import type { OidcMetadata } from "./OidcMetadata";
+import type { StateStore } from "./StateStore";
 
 const DefaultResponseType = "code";
 const DefaultScope = "openid";

--- a/src/ResponseValidator.ts
+++ b/src/ResponseValidator.ts
@@ -2,15 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Log, JoseUtil, Timer } from "./utils";
-import { MetadataService } from "./MetadataService";
+import type { MetadataService } from "./MetadataService";
 import { UserInfoService } from "./UserInfoService";
 import { TokenClient } from "./TokenClient";
 import { ErrorResponse } from "./ErrorResponse";
-import { OidcClientSettingsStore } from "./OidcClientSettings";
-import { SigninState } from "./SigninState";
-import { SigninResponse } from "./SigninResponse";
-import { State } from "./State";
-import { SignoutResponse } from "./SignoutResponse";
+import type { OidcClientSettingsStore } from "./OidcClientSettings";
+import type { SigninState } from "./SigninState";
+import type { SigninResponse } from "./SigninResponse";
+import type { State } from "./State";
+import type { SignoutResponse } from "./SignoutResponse";
 
 const ProtocolClaims = ["nonce", "at_hash", "iat", "nbf", "exp", "aud", "iss", "c_hash"];
 

--- a/src/SessionMonitor.ts
+++ b/src/SessionMonitor.ts
@@ -3,8 +3,8 @@
 
 import { Log, IntervalTimer, g_timer } from "./utils";
 import { CheckSessionIFrame } from "./CheckSessionIFrame";
-import { UserManager } from "./UserManager";
-import { User } from "./User";
+import type { UserManager } from "./UserManager";
+import type { User } from "./User";
 
 export class SessionMonitor {
     private readonly _userManager: UserManager;

--- a/src/SilentRenewService.ts
+++ b/src/SilentRenewService.ts
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Log } from "./utils";
-import { UserManager } from "./UserManager";
-import { AccessTokenCallback } from "./AccessTokenEvents";
+import type { UserManager } from "./UserManager";
+import type { AccessTokenCallback } from "./AccessTokenEvents";
 
 export class SilentRenewService {
     private _userManager: UserManager;

--- a/src/State.ts
+++ b/src/State.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Log, random, Timer } from "./utils";
-import { StateStore } from "./StateStore";
+import type { StateStore } from "./StateStore";
 
 export class State {
     public readonly id: string;

--- a/src/TokenClient.ts
+++ b/src/TokenClient.ts
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { JsonService } from "./JsonService";
-import { MetadataService } from "./MetadataService";
+import type { MetadataService } from "./MetadataService";
 import { Log } from "./utils";
-import { OidcClientSettingsStore } from "./OidcClientSettings";
+import type { OidcClientSettingsStore } from "./OidcClientSettings";
 
 interface ExchangeCodeArgs {
     client_id?: string;

--- a/src/TokenRevocationClient.ts
+++ b/src/TokenRevocationClient.ts
@@ -42,7 +42,7 @@ export class TokenRevocationClient {
         Log.debug("TokenRevocationClient.revoke: Revoking " + type);
         const client_id = this._settings.client_id;
         const client_secret = this._settings.client_secret;
-        return this._revoke(url, client_id, client_secret, token, type);
+        await this._revoke(url, client_id, client_secret, token, type);
     }
 
     protected async _revoke(url: string, client_id: string, client_secret: string | undefined, token: string, type: string): Promise<void> {

--- a/src/TokenRevocationClient.ts
+++ b/src/TokenRevocationClient.ts
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Log } from "./utils";
-import { MetadataService } from "./MetadataService";
-import { OidcClientSettingsStore } from "./OidcClientSettings";
+import type { MetadataService } from "./MetadataService";
+import type { OidcClientSettingsStore } from "./OidcClientSettings";
 
 const AccessTokenTypeHint = "access_token";
 const RefreshTokenTypeHint = "refresh_token";

--- a/src/UserInfoService.ts
+++ b/src/UserInfoService.ts
@@ -3,8 +3,8 @@
 
 import { Log, JoseUtil } from "./utils";
 import { JsonService } from "./JsonService";
-import { MetadataService } from "./MetadataService";
-import { OidcClientSettingsStore } from "./OidcClientSettings";
+import type { MetadataService } from "./MetadataService";
+import type { OidcClientSettingsStore } from "./OidcClientSettings";
 
 export class UserInfoService {
     private _settings: OidcClientSettingsStore;

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -12,10 +12,10 @@ import { SessionMonitor } from "./SessionMonitor";
 import { SigninRequest } from "./SigninRequest";
 import { TokenRevocationClient } from "./TokenRevocationClient";
 import { TokenClient } from "./TokenClient";
-import { SessionStatus } from "./SessionStatus";
-import { SignoutResponse } from "./SignoutResponse";
+import type { SessionStatus } from "./SessionStatus";
+import type { SignoutResponse } from "./SignoutResponse";
 import { ErrorResponse } from "./ErrorResponse";
-import { MetadataService } from "./MetadataService";
+import type { MetadataService } from "./MetadataService";
 
 type SigninArgs = CreateSigninRequestArgs & { current_sub?: string };
 type SignoutArgs = CreateSignoutRequestArgs;

--- a/src/UserManagerEvents.ts
+++ b/src/UserManagerEvents.ts
@@ -3,8 +3,8 @@
 
 import { Log, Event } from "./utils";
 import { AccessTokenEvents } from "./AccessTokenEvents";
-import { UserManagerSettingsStore } from "./UserManagerSettings";
-import { User } from "./User";
+import type { UserManagerSettingsStore } from "./UserManagerSettings";
+import type { User } from "./User";
 
 export type UserLoadedCallback = (user: User) => Promise<void> | void;
 export type UserUnloadedCallback = () => Promise<void> | void;

--- a/src/WebStorageStateStore.ts
+++ b/src/WebStorageStateStore.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Log } from "./utils";
-import { StateStore } from "./StateStore";
+import type { StateStore } from "./StateStore";
 
 export class WebStorageStateStore implements StateStore {
     private _store: Storage

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,17 +4,17 @@
 import { Log } from "./utils";
 
 import { OidcClient } from "./OidcClient";
-import { OidcClientSettings } from "./OidcClientSettings";
+import type { OidcClientSettings } from "./OidcClientSettings";
 import { WebStorageStateStore } from "./WebStorageStateStore";
 import { InMemoryWebStorage } from "./InMemoryWebStorage";
 import { UserManager } from "./UserManager";
-import { UserManagerSettings } from "./UserManagerSettings";
+import type { UserManagerSettings } from "./UserManagerSettings";
 import { AccessTokenEvents } from "./AccessTokenEvents";
 import { MetadataService } from "./MetadataService";
 import { CheckSessionIFrame } from "./CheckSessionIFrame";
 import { TokenRevocationClient } from "./TokenRevocationClient";
 import { SessionMonitor } from "./SessionMonitor";
-import { SessionStatus } from "./SessionStatus";
+import type { SessionStatus } from "./SessionStatus";
 import { User } from "./User";
 import { Version } from "./Version";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,40 +1,19 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { Log } from "./utils";
+export { Log } from "./utils";
 
-import { OidcClient } from "./OidcClient";
-import type { OidcClientSettings } from "./OidcClientSettings";
-import { WebStorageStateStore } from "./WebStorageStateStore";
-import { InMemoryWebStorage } from "./InMemoryWebStorage";
-import { UserManager } from "./UserManager";
-import type { UserManagerSettings } from "./UserManagerSettings";
-import { AccessTokenEvents } from "./AccessTokenEvents";
-import { MetadataService } from "./MetadataService";
-import { CheckSessionIFrame } from "./CheckSessionIFrame";
-import { TokenRevocationClient } from "./TokenRevocationClient";
-import { SessionMonitor } from "./SessionMonitor";
-import type { SessionStatus } from "./SessionStatus";
-import { User } from "./User";
-import { Version } from "./Version";
-
-export type {
-    OidcClientSettings,
-    UserManagerSettings,
-    SessionStatus
-};
-
-export {
-    Version,
-    Log,
-    OidcClient,
-    WebStorageStateStore,
-    InMemoryWebStorage,
-    UserManager,
-    AccessTokenEvents,
-    MetadataService,
-    CheckSessionIFrame,
-    TokenRevocationClient,
-    SessionMonitor,
-    User
-};
+export { OidcClient } from "./OidcClient";
+export type { OidcClientSettings } from "./OidcClientSettings";
+export { WebStorageStateStore } from "./WebStorageStateStore";
+export { InMemoryWebStorage } from "./InMemoryWebStorage";
+export { UserManager } from "./UserManager";
+export type { UserManagerSettings } from "./UserManagerSettings";
+export { AccessTokenEvents } from "./AccessTokenEvents";
+export { MetadataService } from "./MetadataService";
+export { CheckSessionIFrame } from "./CheckSessionIFrame";
+export { TokenRevocationClient } from "./TokenRevocationClient";
+export { SessionMonitor } from "./SessionMonitor";
+export type { SessionStatus } from "./SessionStatus";
+export { User } from "./User";
+export { Version } from "./Version";

--- a/src/navigators/IFrameNavigator.ts
+++ b/src/navigators/IFrameNavigator.ts
@@ -3,8 +3,8 @@
 
 import { Log } from "../utils";
 import { IFrameWindow } from "./IFrameWindow";
-import { INavigator } from "./INavigator";
-import { IWindow } from "./IWindow";
+import type { INavigator } from "./INavigator";
+import type { IWindow } from "./IWindow";
 
 export class IFrameNavigator implements INavigator {
     public prepare(): Promise<IWindow> {

--- a/src/navigators/IFrameWindow.ts
+++ b/src/navigators/IFrameWindow.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Log } from "../utils";
-import { IWindow, NavigatorParams } from "./IWindow";
+import type { IWindow, NavigatorParams } from "./IWindow";
 
 const DefaultTimeoutInSeconds = 10;
 

--- a/src/navigators/INavigator.ts
+++ b/src/navigators/INavigator.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import { IWindow, NavigatorParams } from "./IWindow";
+import type { IWindow, NavigatorParams } from "./IWindow";
 
 export interface INavigator {
     prepare(params: NavigatorParams): Promise<IWindow>;

--- a/src/navigators/PopupNavigator.ts
+++ b/src/navigators/PopupNavigator.ts
@@ -3,8 +3,8 @@
 
 import { Log } from "../utils";
 import { PopupWindow } from "./PopupWindow";
-import { INavigator } from "./INavigator";
-import { IWindow, NavigatorParams } from "./IWindow";
+import type { INavigator } from "./INavigator";
+import type { IWindow, NavigatorParams } from "./IWindow";
 
 export class PopupNavigator implements INavigator {
     public prepare(params: NavigatorParams): Promise<IWindow> {

--- a/src/navigators/PopupWindow.ts
+++ b/src/navigators/PopupWindow.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Log, UrlUtility } from "../utils";
-import { IWindow, NavigatorParams } from "./IWindow";
+import type { IWindow, NavigatorParams } from "./IWindow";
 
 const CheckForPopupClosedInterval = 500;
 const DefaultPopupFeatures = "location=no,toolbar=no,width=500,height=500,left=100,top=100;";

--- a/src/navigators/RedirectNavigator.ts
+++ b/src/navigators/RedirectNavigator.ts
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Log } from "../utils";
-import { INavigator } from "./INavigator";
-import { IWindow, NavigatorParams } from "./IWindow";
+import type { INavigator } from "./INavigator";
+import type { IWindow, NavigatorParams } from "./IWindow";
 
 export class RedirectNavigator implements INavigator, IWindow {
     public prepare(): Promise<IWindow> {

--- a/test/unit/AccessTokenEvents.test.ts
+++ b/test/unit/AccessTokenEvents.test.ts
@@ -3,7 +3,7 @@
 
 import { Timer } from "../../src/utils";
 import { AccessTokenEvents } from "../../src/AccessTokenEvents";
-import { User } from "../../src/User";
+import type { User } from "../../src/User";
 
 describe("AccessTokenEvents", () => {
 

--- a/test/unit/OidcClient.test.ts
+++ b/test/unit/OidcClient.test.ts
@@ -9,7 +9,7 @@ import { State } from "../../src/State";
 import { SigninRequest } from "../../src/SigninRequest";
 import { SignoutRequest } from "../../src/SignoutRequest";
 import { SignoutResponse } from "../../src/SignoutResponse";
-import { ErrorResponse } from "../../src/ErrorResponse";
+import type { ErrorResponse } from "../../src/ErrorResponse";
 
 describe("OidcClient", () => {
     let subject: OidcClient;

--- a/test/unit/OidcClientSettings.test.ts
+++ b/test/unit/OidcClientSettings.test.ts
@@ -3,7 +3,7 @@
 
 import { Log } from "../../src/utils";
 import { OidcClientSettingsStore } from "../../src/OidcClientSettings";
-import { StateStore } from "../../src/StateStore";
+import type { StateStore } from "../../src/StateStore";
 
 describe("OidcClientSettings", () => {
 

--- a/test/unit/ResponseValidator.test.ts
+++ b/test/unit/ResponseValidator.test.ts
@@ -4,10 +4,10 @@
 import { Log, JoseUtil } from "../../src/utils";
 import { ResponseValidator } from "../../src/ResponseValidator";
 import { MetadataService } from "../../src/MetadataService";
-import { UserInfoService } from "../../src/UserInfoService";
+import type { UserInfoService } from "../../src/UserInfoService";
 import { SigninState } from "../../src/SigninState";
-import { SigninResponse } from "../../src/SigninResponse";
-import { ErrorResponse } from "../../src/ErrorResponse";
+import type { SigninResponse } from "../../src/SigninResponse";
+import type { ErrorResponse } from "../../src/ErrorResponse";
 
 // access private methods
 class ResponseValidatorWrapper extends ResponseValidator {

--- a/test/unit/SigninRequest.test.ts
+++ b/test/unit/SigninRequest.test.ts
@@ -143,7 +143,7 @@ describe("SigninRequest", () => {
 
         it("should include state", () => {
             // assert
-            expect(subject.url).toContain("state=" + subject.state?.id);
+            expect(subject.url).toContain("state=" + subject.state.id);
         });
 
         it("should include prompt", () => {

--- a/test/unit/SignoutRequest.test.ts
+++ b/test/unit/SignoutRequest.test.ts
@@ -67,7 +67,8 @@ describe("SignoutRequest", () => {
         it("should include state if post_logout_redirect_uri provided", () => {
             // assert
             expect(subject.state).toBeDefined();
-            expect(subject.url).toContain("state=" + subject.state?.id);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            expect(subject.url).toContain("state=" + subject.state!.id);
         });
 
         it("should not include state if no post_logout_redirect_uri provided", () => {
@@ -88,7 +89,8 @@ describe("SignoutRequest", () => {
             expect(url).toContain("id_token_hint=hint");
             expect(url).toContain("post_logout_redirect_uri=loggedout");
             expect(subject.state).toBeDefined();
-            expect(url).toContain("state=" + subject.state?.id);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            expect(url).toContain("state=" + subject.state!.id);
         });
 
         it("should include extra query params", () => {

--- a/test/unit/UserInfoService.test.ts
+++ b/test/unit/UserInfoService.test.ts
@@ -3,7 +3,7 @@
 
 import { UserInfoService } from "../../src/UserInfoService";
 import { MetadataService } from "../../src/MetadataService";
-import { JsonService } from "../../src/JsonService";
+import type { JsonService } from "../../src/JsonService";
 import { OidcClientSettingsStore } from "../../src/OidcClientSettings";
 
 describe("UserInfoService", () => {

--- a/test/unit/UserManager.test.ts
+++ b/test/unit/UserManager.test.ts
@@ -8,7 +8,7 @@ import { User } from "../../src/User";
 import { WebStorageStateStore } from "../../src/WebStorageStateStore";
 
 import { mocked } from "ts-jest/utils";
-import { INavigator } from "../../src/navigators";
+import type { INavigator } from "../../src/navigators";
 
 describe("UserManager", () => {
     let settings: UserManagerSettings;

--- a/test/unit/UserManagerSettings.test.ts
+++ b/test/unit/UserManagerSettings.test.ts
@@ -3,7 +3,7 @@
 
 import { Log } from "../../src/utils";
 import { UserManagerSettingsStore } from "../../src/UserManagerSettings";
-import { WebStorageStateStore } from "../../src/WebStorageStateStore";
+import type { WebStorageStateStore } from "../../src/WebStorageStateStore";
 
 describe("UserManagerSettings", () => {
 

--- a/test/unit/tsconfig.json
+++ b/test/unit/tsconfig.json
@@ -1,3 +1,8 @@
 {
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "../..",
+        "noEmit": true
+    },
     "include": ["."]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,12 +14,6 @@
     "rootDir": "./src",
     // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,
-    // linter checks for common issues
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
     // interop between ESM and CJS modules. Recommended by TS

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,7 @@
     "forceConsistentCasingInFileNames": true,
     // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
     "noEmit": true,
+    // ensure type imports are side-effect free by enforcing that `import type` is used
+    "importsNotUsedAsValues": "error",
   }
 }


### PR DESCRIPTION
This should be the last PR before I send over the big refactor with the esbuild changes that should actually have tangible implications on the the library output :^)

This fixes up some tsconfig problems, namely
* unit tests only used loose type checking since they have their own tsconfig that didn't extend from the main project's
* `tsc` was unnecessarily performing some linting tasks that are already handled by ESLint (`noImplicitReturns`, `noFallthroughCasesInSwitch`, `noUnusedLocals`, `noUnusedParameters`)
  * `consistent-return` is actually slightly more strict than `noImplicitReturns` in that doesn't find it acceptable to inconsistently return a `Promise<void>` in a void async function.
* I've also enabled `importsNotUsedAsValues` and fixed all instances of the rule. It's primary useful in the following scenario:
  ```typescript
  // this import needs to be stripped in the output as it doesn't import runtime code
  import { OtherClass } from './foo';
  
  export class MyClass {
    // this is difficult to tree-shake - the bundler must evaluate that `OtherClass` is unused
    // and then assert that `import './foo'` is pure
    foo: OtherClass;
  }
  ```