### PR TITLE
Support passing window params to UserManager functions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -47,6 +47,7 @@ overrides:
         - error
         - always
       # custom rules to fix code style
+      "@typescript-eslint/require-await": "off"
       "@typescript-eslint/no-unsafe-assignment": "off"
       "@typescript-eslint/no-unsafe-call": "off"
       "@typescript-eslint/no-unsafe-member-access": "off"

--- a/docs/oidc-client-ts.api.md
+++ b/docs/oidc-client-ts.api.md
@@ -27,7 +27,7 @@ export class AccessTokenEvents {
 
 // @public (undocumented)
 export class CheckSessionIFrame {
-    constructor(callback: () => Promise<void> | void, client_id: string, url: string, intervalInSeconds: number, stopOnError: boolean);
+    constructor(_callback: () => Promise<void>, _client_id: string, url: string, _intervalInSeconds: number, _stopOnError: boolean);
     // (undocumented)
     load(): Promise<void>;
     // (undocumented)
@@ -208,19 +208,19 @@ export interface OidcClientSettings {
 export class SessionMonitor {
     constructor(userManager: UserManager);
     // (undocumented)
-    protected _callback(): Promise<void>;
+    protected _callback: () => Promise<void>;
     // (undocumented)
     protected _init(): Promise<void>;
     // (undocumented)
-    protected _start(user: User | {
+    protected _start: (user: User | {
         session_state: string;
         profile: {
             sub: string;
             sid: string;
         } | null;
-    }): Promise<void>;
+    }) => Promise<void>;
     // (undocumented)
-    protected _stop(): void;
+    protected _stop: () => void;
 }
 
 // @public (undocumented)
@@ -310,7 +310,7 @@ export class UserManager {
     // (undocumented)
     protected readonly _popupNavigator: PopupNavigator;
     // (undocumented)
-    querySessionStatus(): Promise<SessionStatus | null>;
+    querySessionStatus({ silentRequestTimeoutInSeconds, ...args }?: IFrameWindowParams & ExtraSigninRequestArgs): Promise<SessionStatus | null>;
     // Warning: (ae-forgotten-export) The symbol "RedirectNavigator" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -331,55 +331,57 @@ export class UserManager {
     //
     // (undocumented)
     readonly settings: UserManagerSettingsStore;
-    // Warning: (ae-forgotten-export) The symbol "INavigator" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "NavigateParams" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "IWindow" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    protected _signin(args: SigninArgs, navigator: INavigator, navigatorParams: NavigateParams): Promise<User>;
+    protected _signin(args: CreateSigninRequestArgs, handle: IWindow, verifySub?: string): Promise<User>;
     // (undocumented)
     signinCallback(url?: string): Promise<User | null>;
     // (undocumented)
     protected _signinCallback(url: string | undefined, navigator: IFrameNavigator | PopupNavigator): Promise<void>;
     // (undocumented)
-    protected _signinEnd(url?: string, args?: SigninArgs): Promise<User>;
-    // (undocumented)
-    signinPopup(): Promise<User>;
-    // (undocumented)
-    signinPopupCallback(url?: string): Promise<void>;
-    // (undocumented)
-    signinRedirect(): Promise<void>;
-    // (undocumented)
-    signinRedirectCallback(url?: string): Promise<User>;
-    // (undocumented)
-    signinSilent(): Promise<User | null>;
-    // (undocumented)
-    signinSilentCallback(url?: string): Promise<void>;
-    // Warning: (ae-forgotten-export) The symbol "SigninArgs" needs to be exported by the entry point index.d.ts
+    protected _signinEnd(url: string, verifySub?: string): Promise<User>;
+    // Warning: (ae-forgotten-export) The symbol "PopupWindowParams" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    protected _signinSilentIframe(args: SigninArgs): Promise<User>;
+    signinPopup({ popupWindowFeatures, popupWindowTarget, ...args }?: PopupWindowParams & ExtraSigninRequestArgs): Promise<User>;
+    // (undocumented)
+    signinPopupCallback(url?: string): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "RedirectParams" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "ExtraSigninRequestArgs" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    signinRedirect({ redirectMethod, ...args }?: RedirectParams & ExtraSigninRequestArgs): Promise<void>;
+    // (undocumented)
+    signinRedirectCallback(url?: string): Promise<User>;
+    // Warning: (ae-forgotten-export) The symbol "IFrameWindowParams" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    signinSilent({ silentRequestTimeoutInSeconds, ...args }?: IFrameWindowParams & ExtraSigninRequestArgs): Promise<User | null>;
+    // (undocumented)
+    signinSilentCallback(url?: string): Promise<void>;
     // Warning: (ae-forgotten-export) The symbol "NavigateResponse" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    protected _signinStart(args: SigninArgs, navigator: INavigator, navigatorParams: NavigateParams): Promise<NavigateResponse>;
-    // Warning: (ae-forgotten-export) The symbol "SignoutArgs" needs to be exported by the entry point index.d.ts
-    //
+    protected _signinStart(args: CreateSigninRequestArgs, handle: IWindow): Promise<NavigateResponse>;
     // (undocumented)
-    protected _signout(args: SignoutArgs, navigator: INavigator, navigatorParams: NavigateParams): Promise<SignoutResponse>;
+    protected _signout(args: CreateSignoutRequestArgs, handle: IWindow): Promise<SignoutResponse>;
     // (undocumented)
     signoutCallback(url?: string, keepOpen?: boolean): Promise<void>;
     // (undocumented)
     protected _signoutEnd(url: string): Promise<SignoutResponse>;
     // (undocumented)
-    signoutPopup(): Promise<void>;
+    signoutPopup({ popupWindowFeatures, popupWindowTarget, ...args }?: PopupWindowParams & ExtraSignoutRequestArgs): Promise<void>;
     // (undocumented)
     signoutPopupCallback(url: any, keepOpen: any): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "ExtraSignoutRequestArgs" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    signoutRedirect(): Promise<void>;
+    signoutRedirect({ redirectMethod, ...args }?: RedirectParams & ExtraSignoutRequestArgs): Promise<void>;
     // (undocumented)
     signoutRedirectCallback(url?: string): Promise<SignoutResponse>;
     // (undocumented)
-    protected _signoutStart(args: CreateSignoutRequestArgs | undefined, navigator: INavigator, navigatorParams?: NavigateParams): Promise<any>;
+    protected _signoutStart(args: CreateSignoutRequestArgs | undefined, handle: IWindow): Promise<any>;
     // Warning: (ae-forgotten-export) The symbol "SilentRenewService" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/src/CheckSessionIFrame.ts
+++ b/src/CheckSessionIFrame.ts
@@ -30,8 +30,9 @@ export class CheckSessionIFrame {
 
         // shotgun approach
         this._frame.style.visibility = "hidden";
-        this._frame.style.position = "absolute";
-        this._frame.style.display = "none";
+        this._frame.style.position = "fixed";
+        this._frame.style.left = "-1000px";
+        this._frame.style.top = "0";
         this._frame.width = "0";
         this._frame.height = "0";
         this._frame.src = url;

--- a/src/SessionMonitor.ts
+++ b/src/SessionMonitor.ts
@@ -25,8 +25,8 @@ export class SessionMonitor {
         this._userManager = userManager;
         this._timer = g_timer;
 
-        this._userManager.events.addUserLoaded(this._start.bind(this));
-        this._userManager.events.addUserUnloaded(this._stop.bind(this));
+        this._userManager.events.addUserLoaded(this._start);
+        this._userManager.events.addUserUnloaded(this._stop);
 
         Promise.resolve(this._init())
             .catch((err: Error) => {
@@ -57,13 +57,12 @@ export class SessionMonitor {
         }
     }
 
-    protected async _start(user: User | {
-        session_state: string;
-        profile: {
-            sub: string;
-            sid: string;
-        } | null;
-    }): Promise<void> {
+    protected _start = async (
+        user: User | {
+            session_state: string;
+            profile: { sub: string; sid: string } | null;
+        }
+    ): Promise<void> => {
         const session_state = user.session_state;
         if (!session_state) {
             return;
@@ -94,7 +93,7 @@ export class SessionMonitor {
                 const intervalInSeconds = this._userManager.settings.checkSessionIntervalInSeconds;
                 const stopOnError = this._userManager.settings.stopCheckSessionOnError;
 
-                const checkSessionIFrame = new CheckSessionIFrame(this._callback.bind(this), client_id, url, intervalInSeconds, stopOnError);
+                const checkSessionIFrame = new CheckSessionIFrame(this._callback, client_id, url, intervalInSeconds, stopOnError);
                 await checkSessionIFrame.load();
                 this._checkSessionIFrame = checkSessionIFrame;
                 checkSessionIFrame.start(session_state);
@@ -109,7 +108,7 @@ export class SessionMonitor {
         }
     }
 
-    protected _stop(): void {
+    protected _stop = (): void => {
         this._sub = undefined;
         this._sid = undefined;
 
@@ -146,7 +145,7 @@ export class SessionMonitor {
         }
     }
 
-    protected async _callback(): Promise<void> {
+    protected _callback = async (): Promise<void> => {
         try {
             const session = await this._userManager.querySessionStatus();
             let raiseEvent = true;

--- a/src/UserInfoService.ts
+++ b/src/UserInfoService.ts
@@ -13,7 +13,7 @@ export class UserInfoService {
 
     public constructor(settings: OidcClientSettingsStore, metadataService: MetadataService) {
         this._settings = settings;
-        this._jsonService = new JsonService(undefined, this._getClaimsFromJwt.bind(this));
+        this._jsonService = new JsonService(undefined, this._getClaimsFromJwt);
         this._metadataService = metadataService;
     }
 
@@ -32,7 +32,7 @@ export class UserInfoService {
         return claims;
     }
 
-    protected async _getClaimsFromJwt(responseText: string): Promise<any> {
+    protected _getClaimsFromJwt = async (responseText: string): Promise<any> => {
         try {
             const jwt = JoseUtil.parseJwt(responseText);
             if (!jwt || !jwt.header || !jwt.payload) {

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -101,8 +101,9 @@ export class UserManager {
         });
         Log.info("UserManager.signinRedirect: successful");
     }
-    public async signinRedirectCallback(url?: string): Promise<User> {
-        const user = await this._signinEnd(url || this._redirectNavigator.url);
+
+    public async signinRedirectCallback(url = window.location.href): Promise<User> {
+        const user = await this._signinEnd(url);
         if (user.profile && user.profile.sub) {
             Log.info("UserManager.signinRedirectCallback: successful, signed in sub: ", user.profile.sub);
         }
@@ -386,11 +387,11 @@ export class UserManager {
 
         return user;
     }
-    protected _signinCallback(url: string | undefined, navigator: IFrameNavigator | PopupNavigator): Promise<void> {
+    protected async _signinCallback(url: string | undefined, navigator: IFrameNavigator | PopupNavigator): Promise<void> {
         Log.debug("UserManager._signinCallback");
         const useQuery = this.settings.response_mode === "query" || (!this.settings.response_mode && SigninRequest.isCode(this.settings.response_type));
         const delimiter = useQuery ? "?" : "#";
-        return navigator.callback(url, false, delimiter);
+        await navigator.callback(url, false, delimiter);
     }
 
     public async signoutRedirect(): Promise<void> {
@@ -405,8 +406,8 @@ export class UserManager {
         await this._signoutStart(args, this._redirectNavigator);
         Log.info("UserManager.signoutRedirect: successful");
     }
-    public async signoutRedirectCallback(url?: string): Promise<SignoutResponse> {
-        const response = await this._signoutEnd(url || this._redirectNavigator.url);
+    public async signoutRedirectCallback(url = window.location.href): Promise<SignoutResponse> {
+        const response = await this._signoutEnd(url);
         Log.info("UserManager.signoutRedirectCallback: successful");
         return response;
     }

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -29,8 +29,6 @@ export class UserManager {
     protected readonly _iframeNavigator: IFrameNavigator;
     protected readonly _events: UserManagerEvents;
     protected readonly _silentRenewService: SilentRenewService;
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     protected readonly _sessionMonitor: SessionMonitor | null;
     protected readonly _tokenRevocationClient: TokenRevocationClient;
     protected readonly _tokenClient: TokenClient;
@@ -40,9 +38,9 @@ export class UserManager {
 
         this._client = new OidcClient(settings);
 
-        this._redirectNavigator = new RedirectNavigator();
-        this._popupNavigator = new PopupNavigator();
-        this._iframeNavigator = new IFrameNavigator();
+        this._redirectNavigator = new RedirectNavigator(this.settings);
+        this._popupNavigator = new PopupNavigator(this.settings);
+        this._iframeNavigator = new IFrameNavigator(this.settings);
 
         this._events = new UserManagerEvents(this.settings);
         this._silentRenewService = new SilentRenewService(this);

--- a/src/UserManager.ts
+++ b/src/UserManager.ts
@@ -127,7 +127,6 @@ export class UserManager {
             display: "popup"
         };
         const user = await this._signin(args, this._popupNavigator, {
-            startUrl: url,
             popupWindowFeatures: this.settings.popupWindowFeatures,
             popupWindowTarget: this.settings.popupWindowTarget,
             redirectMethod: this.settings.redirectMethod
@@ -239,7 +238,6 @@ export class UserManager {
         args.prompt = args.prompt || "none";
 
         const user = await this._signin(args, this._iframeNavigator, {
-            startUrl: url,
             silentRequestTimeoutInSeconds: this.settings.silentRequestTimeoutInSeconds
         });
         if (user) {
@@ -304,7 +302,6 @@ export class UserManager {
             skipUserInfo: true
         };
         const navResponse = await this._signinStart(args, this._iframeNavigator, {
-            startUrl: url,
             silentRequestTimeoutInSeconds: this.settings.silentRequestTimeoutInSeconds,
             redirectMethod: this.settings.redirectMethod
         });
@@ -428,7 +425,6 @@ export class UserManager {
         }
 
         await this._signout(args, this._popupNavigator, {
-            startUrl: url,
             popupWindowFeatures: this.settings.popupWindowFeatures,
             popupWindowTarget: this.settings.popupWindowTarget
         });

--- a/src/UserManagerSettings.ts
+++ b/src/UserManagerSettings.ts
@@ -57,7 +57,7 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
     public readonly popup_post_logout_redirect_uri: string | undefined;
     public readonly popupWindowFeatures: string | undefined;
     public readonly popupWindowTarget: string | undefined;
-    public readonly redirectMethod: "replace" | "assign" | undefined;
+    public readonly redirectMethod: "replace" | "assign";
 
     public readonly silent_redirect_uri: string | undefined;
     public readonly silentRequestTimeoutInSeconds: number | undefined;
@@ -82,7 +82,7 @@ export class UserManagerSettingsStore extends OidcClientSettingsStore {
             popup_post_logout_redirect_uri,
             popupWindowFeatures,
             popupWindowTarget,
-            redirectMethod,
+            redirectMethod = "assign",
 
             silent_redirect_uri,
             silentRequestTimeoutInSeconds,

--- a/src/navigators/IFrameNavigator.ts
+++ b/src/navigators/IFrameNavigator.ts
@@ -9,8 +9,10 @@ import type { INavigator } from "./INavigator";
 export class IFrameNavigator implements INavigator {
     constructor(private _settings: UserManagerSettingsStore) {}
 
-    public async prepare(params: IFrameWindowParams): Promise<IFrameWindow> {
-        return new IFrameWindow({ ...this._settings, ...params });
+    public async prepare({
+        silentRequestTimeoutInSeconds = this._settings.silentRequestTimeoutInSeconds
+    }: IFrameWindowParams): Promise<IFrameWindow> {
+        return new IFrameWindow({ silentRequestTimeoutInSeconds });
     }
 
     public async callback(url: string | undefined): Promise<void> {

--- a/src/navigators/IFrameNavigator.ts
+++ b/src/navigators/IFrameNavigator.ts
@@ -1,13 +1,16 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+import type { UserManagerSettingsStore } from "../UserManagerSettings";
 import { Log } from "../utils";
 import { IFrameWindow, IFrameWindowParams } from "./IFrameWindow";
 import type { INavigator } from "./INavigator";
 
 export class IFrameNavigator implements INavigator {
+    constructor(private _settings: UserManagerSettingsStore) {}
+
     public async prepare(params: IFrameWindowParams): Promise<IFrameWindow> {
-        return new IFrameWindow(params);
+        return new IFrameWindow({ ...this._settings, ...params });
     }
 
     public async callback(url: string | undefined): Promise<void> {

--- a/src/navigators/IFrameNavigator.ts
+++ b/src/navigators/IFrameNavigator.ts
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Log } from "../utils";
-import { IFrameWindow } from "./IFrameWindow";
+import { IFrameWindow, IFrameWindowParams } from "./IFrameWindow";
 import type { INavigator } from "./INavigator";
 
 export class IFrameNavigator implements INavigator {
-    public async prepare(): Promise<IFrameWindow> {
-        return new IFrameWindow();
+    public async prepare(params: IFrameWindowParams): Promise<IFrameWindow> {
+        return new IFrameWindow(params);
     }
 
     public async callback(url: string | undefined): Promise<void> {

--- a/src/navigators/IFrameNavigator.ts
+++ b/src/navigators/IFrameNavigator.ts
@@ -4,22 +4,14 @@
 import { Log } from "../utils";
 import { IFrameWindow } from "./IFrameWindow";
 import type { INavigator } from "./INavigator";
-import type { IWindow } from "./IWindow";
 
 export class IFrameNavigator implements INavigator {
-    public prepare(): Promise<IWindow> {
-        const frame = new IFrameWindow();
-        return Promise.resolve(frame);
+    public async prepare(): Promise<IFrameWindow> {
+        return new IFrameWindow();
     }
 
-    public callback(url: string | undefined): Promise<void> {
+    public async callback(url: string | undefined): Promise<void> {
         Log.debug("IFrameNavigator.callback");
-        try {
-            IFrameWindow.notifyParent(url);
-            return Promise.resolve();
-        }
-        catch (err) {
-            return Promise.reject(err);
-        }
+        IFrameWindow.notifyParent(url);
     }
 }

--- a/src/navigators/IFrameWindow.ts
+++ b/src/navigators/IFrameWindow.ts
@@ -32,7 +32,7 @@ export class IFrameWindow implements IWindow {
         window.document.body.appendChild(this._frame);
     }
 
-    public navigate(params: NavigateParams): Promise<NavigateResponse> {
+    public async navigate(params: NavigateParams): Promise<NavigateResponse> {
         if (!params || !params.url) {
             this._error("No url provided");
         }
@@ -46,7 +46,7 @@ export class IFrameWindow implements IWindow {
             this._frame.src = params.url;
         }
 
-        return this._promise;
+        return await this._promise;
     }
 
     protected _success(data: any): void {

--- a/src/navigators/IFrameWindow.ts
+++ b/src/navigators/IFrameWindow.ts
@@ -27,7 +27,9 @@ export class IFrameWindow implements IWindow {
 
         // shotgun approach
         this._frame.style.visibility = "hidden";
-        this._frame.style.position = "absolute";
+        this._frame.style.position = "fixed";
+        this._frame.style.left = "-1000px";
+        this._frame.style.top = "0";
         this._frame.width = "0";
         this._frame.height = "0";
 

--- a/src/navigators/IFrameWindow.ts
+++ b/src/navigators/IFrameWindow.ts
@@ -4,7 +4,11 @@
 import { Log } from "../utils";
 import type { IWindow, NavigateParams, NavigateResponse } from "./IWindow";
 
-const DefaultTimeoutInSeconds = 10;
+const defaultTimeoutInSeconds = 10;
+
+export interface IFrameWindowParams {
+    silentRequestTimeoutInSeconds?: number;
+}
 
 export class IFrameWindow implements IWindow {
     private _resolve!: (value: NavigateResponse) => void;
@@ -13,10 +17,14 @@ export class IFrameWindow implements IWindow {
         this._resolve = resolve;
         this._reject = reject;
     })
+    private _timeoutInSeconds: number;
     private _frame: HTMLIFrameElement | null;
     private _timer: number | null = null;
 
-    public constructor() {
+    public constructor({
+        silentRequestTimeoutInSeconds = defaultTimeoutInSeconds
+    }: IFrameWindowParams) {
+        this._timeoutInSeconds = silentRequestTimeoutInSeconds;
         window.addEventListener("message", this._message, false);
 
         this._frame = window.document.createElement("iframe");
@@ -40,9 +48,8 @@ export class IFrameWindow implements IWindow {
             this._error("No _frame, already closed");
         }
         else {
-            const timeoutInSeconds = params.silentRequestTimeoutInSeconds || DefaultTimeoutInSeconds;
-            Log.debug("IFrameWindow.navigate: Using timeout of:", timeoutInSeconds);
-            this._timer = window.setTimeout(this._timeout, timeoutInSeconds * 1000);
+            Log.debug("IFrameWindow.navigate: Using timeout of:", this._timeoutInSeconds);
+            this._timer = window.setTimeout(this._timeout, this._timeoutInSeconds * 1000);
             this._frame.src = params.url;
         }
 

--- a/src/navigators/INavigator.ts
+++ b/src/navigators/INavigator.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-import type { IWindow, NavigateParams } from "./IWindow";
+import type { IWindow } from "./IWindow";
 
 export interface INavigator {
-    prepare(params: NavigateParams): Promise<IWindow>;
+    prepare(params: unknown): Promise<IWindow>;
 }

--- a/src/navigators/IWindow.ts
+++ b/src/navigators/IWindow.ts
@@ -4,7 +4,6 @@
 export interface NavigateParams {
     url?: string;
     id?: string;
-    startUrl?: string;
     popupWindowFeatures?: string;
     popupWindowTarget?: string;
     silentRequestTimeoutInSeconds?: number;

--- a/src/navigators/IWindow.ts
+++ b/src/navigators/IWindow.ts
@@ -2,16 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 export interface NavigateParams {
-    url?: string;
+    url: string;
     id?: string;
-    popupWindowFeatures?: string;
-    popupWindowTarget?: string;
-    silentRequestTimeoutInSeconds?: number;
-    redirectMethod?: "replace" | "assign";
 }
 
 export interface NavigateResponse {
-    url?: string;
+    url: string;
 }
 
 export interface IWindow {

--- a/src/navigators/PopupNavigator.ts
+++ b/src/navigators/PopupNavigator.ts
@@ -4,10 +4,13 @@
 import { Log } from "../utils";
 import { PopupWindow, PopupWindowParams } from "./PopupWindow";
 import type { INavigator } from "./INavigator";
+import type { UserManagerSettingsStore } from "../UserManagerSettings";
 
 export class PopupNavigator implements INavigator {
+    constructor(private _settings: UserManagerSettingsStore) {}
+
     public async prepare(params: PopupWindowParams): Promise<PopupWindow> {
-        return new PopupWindow(params);
+        return new PopupWindow({ ...this._settings, ...params });
     }
 
     public async callback(url: string | undefined, keepOpen: boolean, delimiter: string): Promise<void> {

--- a/src/navigators/PopupNavigator.ts
+++ b/src/navigators/PopupNavigator.ts
@@ -2,12 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 import { Log } from "../utils";
-import { PopupWindow } from "./PopupWindow";
+import { PopupWindow, PopupWindowParams } from "./PopupWindow";
 import type { INavigator } from "./INavigator";
-import type { NavigateParams } from "./IWindow";
 
 export class PopupNavigator implements INavigator {
-    public async prepare(params: NavigateParams): Promise<PopupWindow> {
+    public async prepare(params: PopupWindowParams): Promise<PopupWindow> {
         return new PopupWindow(params);
     }
 

--- a/src/navigators/PopupNavigator.ts
+++ b/src/navigators/PopupNavigator.ts
@@ -4,23 +4,16 @@
 import { Log } from "../utils";
 import { PopupWindow } from "./PopupWindow";
 import type { INavigator } from "./INavigator";
-import type { IWindow, NavigateParams } from "./IWindow";
+import type { NavigateParams } from "./IWindow";
 
 export class PopupNavigator implements INavigator {
-    public prepare(params: NavigateParams): Promise<IWindow> {
-        const popup = new PopupWindow(params);
-        return Promise.resolve(popup);
+    public async prepare(params: NavigateParams): Promise<PopupWindow> {
+        return new PopupWindow(params);
     }
 
-    public callback(url: string | undefined, keepOpen: boolean, delimiter: string): Promise<void> {
+    public async callback(url: string | undefined, keepOpen: boolean, delimiter: string): Promise<void> {
         Log.debug("PopupNavigator.callback");
 
-        try {
-            PopupWindow.notifyOpener(url, keepOpen, delimiter);
-            return Promise.resolve();
-        }
-        catch (err) {
-            return Promise.reject(err);
-        }
+        PopupWindow.notifyOpener(url, keepOpen, delimiter);
     }
 }

--- a/src/navigators/PopupNavigator.ts
+++ b/src/navigators/PopupNavigator.ts
@@ -9,8 +9,11 @@ import type { UserManagerSettingsStore } from "../UserManagerSettings";
 export class PopupNavigator implements INavigator {
     constructor(private _settings: UserManagerSettingsStore) {}
 
-    public async prepare(params: PopupWindowParams): Promise<PopupWindow> {
-        return new PopupWindow({ ...this._settings, ...params });
+    public async prepare({
+        popupWindowFeatures = this._settings.popupWindowFeatures,
+        popupWindowTarget = this._settings.popupWindowTarget,
+    }: PopupWindowParams): Promise<PopupWindow> {
+        return new PopupWindow({ popupWindowFeatures, popupWindowTarget });
     }
 
     public async callback(url: string | undefined, keepOpen: boolean, delimiter: string): Promise<void> {

--- a/src/navigators/PopupWindow.ts
+++ b/src/navigators/PopupWindow.ts
@@ -30,7 +30,7 @@ export class PopupWindow implements IWindow {
         this._checkForPopupClosedTimer = null;
         if (this._popup) {
             Log.debug("PopupWindow.ctor: popup successfully created");
-            this._checkForPopupClosedTimer = window.setInterval(this._checkForPopupClosed.bind(this), CheckForPopupClosedInterval);
+            this._checkForPopupClosedTimer = window.setInterval(this._checkForPopupClosed, CheckForPopupClosedInterval);
         }
     }
 
@@ -47,21 +47,18 @@ export class PopupWindow implements IWindow {
 
             this._id = params.id;
             if (this._id) {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-                window["popupCallback_" + params.id] = this._callback.bind(this);
+                (window as any)["popupCallback_" + params.id!] = this._callback;
             }
 
             this._popup.focus();
             this._popup.window.location[params.redirectMethod || "assign"](params.url);
-            window.addEventListener("message", this._messageReceived.bind(this), false);
+            window.addEventListener("message", this._messageReceived, false);
         }
 
         return this._promise;
     }
 
-    _messageReceived(event: MessageEvent): void {
+    _messageReceived = (event: MessageEvent): void => {
         if (event.origin !== window.location.origin) {
             Log.warn("PopupWindow:messageRecieved: Message not coming from same origin: " + event.origin);
             return;
@@ -112,12 +109,9 @@ export class PopupWindow implements IWindow {
             this._checkForPopupClosedTimer = null;
         }
 
-        window.removeEventListener("message", this._messageReceived.bind(this));
+        window.removeEventListener("message", this._messageReceived);
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-        delete window["popupCallback_" + this._id];
+        delete (window as any)["popupCallback_" + this._id!];
 
         if (this._popup && !keepOpen) {
             this._popup.close();
@@ -125,13 +119,13 @@ export class PopupWindow implements IWindow {
         this._popup = null;
     }
 
-    protected _checkForPopupClosed(): void {
+    protected _checkForPopupClosed = (): void => {
         if (!this._popup || this._popup.closed) {
             this._error("Popup window closed");
         }
     }
 
-    protected _callback(url: string, keepOpen: boolean): void {
+    protected _callback = (url: string, keepOpen: boolean): void => {
         this._cleanup(keepOpen);
 
         if (url) {

--- a/src/navigators/PopupWindow.ts
+++ b/src/navigators/PopupWindow.ts
@@ -34,7 +34,7 @@ export class PopupWindow implements IWindow {
         }
     }
 
-    public navigate(params: NavigateParams): Promise<NavigateResponse> {
+    public async navigate(params: NavigateParams): Promise<NavigateResponse> {
         if (!this._popup) {
             this._error("PopupWindow.navigate: Error opening popup window");
         }
@@ -55,7 +55,7 @@ export class PopupWindow implements IWindow {
             window.addEventListener("message", this._messageReceived, false);
         }
 
-        return this._promise;
+        return await this._promise;
     }
 
     _messageReceived = (event: MessageEvent): void => {

--- a/src/navigators/RedirectNavigator.ts
+++ b/src/navigators/RedirectNavigator.ts
@@ -5,8 +5,15 @@ import { Log } from "../utils";
 import type { INavigator } from "./INavigator";
 import type { IWindow, NavigateParams, NavigateResponse } from "./IWindow";
 
+export interface RedirectParams {
+    redirectMethod?: "replace" | "assign";
+}
+
 export class RedirectNavigator implements INavigator, IWindow {
-    public async prepare(): Promise<IWindow> {
+    private _redirectMethod: "replace" | "assign" = "assign"
+
+    public async prepare({ redirectMethod }: RedirectParams): Promise<RedirectNavigator> {
+        this._redirectMethod = redirectMethod ?? this._redirectMethod;
         return this;
     }
 
@@ -16,7 +23,7 @@ export class RedirectNavigator implements INavigator, IWindow {
             throw new Error("No url provided");
         }
 
-        window.location[params.redirectMethod || "assign"](params.url);
+        window.location[this._redirectMethod](params.url);
         return { url: window.location.href };
     }
 

--- a/src/navigators/RedirectNavigator.ts
+++ b/src/navigators/RedirectNavigator.ts
@@ -6,25 +6,21 @@ import type { INavigator } from "./INavigator";
 import type { IWindow, NavigateParams, NavigateResponse } from "./IWindow";
 
 export class RedirectNavigator implements INavigator, IWindow {
-    public prepare(): Promise<IWindow> {
-        return Promise.resolve(this);
+    public async prepare(): Promise<IWindow> {
+        return this;
     }
 
-    public navigate(params: NavigateParams): Promise<NavigateResponse> {
+    public async navigate(params: NavigateParams): Promise<NavigateResponse> {
         if (!params || !params.url) {
             Log.error("RedirectNavigator.navigate: No url provided");
             throw new Error("No url provided");
         }
 
         window.location[params.redirectMethod || "assign"](params.url);
-        return Promise.resolve(this);
-    }
-
-    public get url(): string {
-        return window.location.href;
+        return { url: window.location.href };
     }
 
     public close(): void {
-        Log.warn("Function not implemented");
+        Log.warn("RedirectNavigator cannot close the current window");
     }
 }

--- a/src/navigators/RedirectNavigator.ts
+++ b/src/navigators/RedirectNavigator.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+import type { UserManagerSettingsStore } from "../UserManagerSettings";
 import { Log } from "../utils";
 import type { INavigator } from "./INavigator";
 import type { IWindow, NavigateParams, NavigateResponse } from "./IWindow";
@@ -10,10 +11,12 @@ export interface RedirectParams {
 }
 
 export class RedirectNavigator implements INavigator, IWindow {
-    private _redirectMethod: "replace" | "assign" = "assign"
+    private _redirectMethod: "replace" | "assign" | undefined;
+
+    constructor(private _settings: UserManagerSettingsStore) {}
 
     public async prepare({ redirectMethod }: RedirectParams): Promise<RedirectNavigator> {
-        this._redirectMethod = redirectMethod ?? this._redirectMethod;
+        this._redirectMethod = redirectMethod ?? this._settings.redirectMethod;
         return this;
     }
 
@@ -23,7 +26,7 @@ export class RedirectNavigator implements INavigator, IWindow {
             throw new Error("No url provided");
         }
 
-        window.location[this._redirectMethod](params.url);
+        window.location[this._redirectMethod!](params.url);
         return { url: window.location.href };
     }
 

--- a/src/utils/Event.ts
+++ b/src/utils/Event.ts
@@ -4,13 +4,9 @@
 import { Log } from "./Log";
 
 export class Event {
-    protected _name: string;
-    private _callbacks: ((...ev: any[]) => Promise<void> | void)[];
+    private _callbacks: ((...ev: any[]) => Promise<void> | void)[] = [];
 
-    public constructor(name: string) {
-        this._name = name;
-        this._callbacks = [];
-    }
+    public constructor(protected _name: string) {}
 
     public addHandler(cb: (...ev: any[]) => Promise<void> | void): void {
         this._callbacks.push(cb);

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -20,16 +20,9 @@ export const g_timer: IntervalTimer = {
 };
 
 export class Timer extends Event {
-    private _timer: IntervalTimer;
-    private _timerHandle: number | null;
-    private _expiration: number;
-
-    public constructor(name: string) {
-        super(name);
-        this._timer = g_timer;
-        this._timerHandle = null;
-        this._expiration = 0;
-    }
+    private _timer = g_timer;
+    private _timerHandle: number | null = null;
+    private _expiration = 0;
 
     // get the time
     public static getEpochTime(): number {
@@ -61,7 +54,7 @@ export class Timer extends Event {
         if (durationInSeconds < timerDurationInSeconds) {
             timerDurationInSeconds = durationInSeconds;
         }
-        this._timerHandle = this._timer.setInterval(this._callback.bind(this), timerDurationInSeconds * 1000);
+        this._timerHandle = this._timer.setInterval(this._callback, timerDurationInSeconds * 1000);
     }
 
     public get expiration(): number {
@@ -76,7 +69,7 @@ export class Timer extends Event {
         }
     }
 
-    protected _callback(): void {
+    protected _callback = (): void => {
         const diff = this._expiration - Timer.getEpochTime();
         Log.debug("Timer.callback; " + this._name + " timer expires in:", diff);
 

--- a/test/unit/PopupWindow.test.ts
+++ b/test/unit/PopupWindow.test.ts
@@ -1,7 +1,7 @@
 import { PopupWindow } from "../../src/navigators/PopupWindow";
 
 describe("PopupWindow", () => {
-    let popupFromWindowOpen: { window: { location: { assign: () => void } }; focus: () => void; close: () => void };
+    let popupFromWindowOpen: { window: { location: { replace: () => void } }; focus: () => void; close: () => void };
 
     beforeEach(() => {
         Object.defineProperty(window, "location", {
@@ -11,7 +11,7 @@ describe("PopupWindow", () => {
 
         window.open = jest.fn().mockImplementation(() => {
             popupFromWindowOpen = {
-                window: { location: { assign: jest.fn() } },
+                window: { location: { replace: jest.fn() } },
                 focus: jest.fn(),
                 close: jest.fn(),
             };
@@ -34,7 +34,7 @@ describe("PopupWindow", () => {
         const popupWindow = new PopupWindow({});
 
         popupWindow.navigate({ url: "https://myidp.com/authorize?x=y", id: "someid" }).then((data) => {
-            expect(popupFromWindowOpen.window.location.assign).toHaveBeenCalledWith("https://myidp.com/authorize?x=y");
+            expect(popupFromWindowOpen.window.location.replace).toHaveBeenCalledWith("https://myidp.com/authorize?x=y");
             expect(data.url).toBe("https://myapp.com");
             done();
         }).catch((err) => {
@@ -51,7 +51,7 @@ describe("PopupWindow", () => {
         const popupWindow = new PopupWindow({});
 
         popupWindow.navigate({ url: "https://myidp.com/authorize?x=y", id: "someid" }).catch((error: Error) => {
-            expect(popupFromWindowOpen.window.location.assign).toHaveBeenCalledWith("https://myidp.com/authorize?x=y");
+            expect(popupFromWindowOpen.window.location.replace).toHaveBeenCalledWith("https://myidp.com/authorize?x=y");
             expect(error.message).toBe("Invalid response from popup");
             done();
         });


### PR DESCRIPTION
Resolves #95.

This restores the ability to customize the window behavior of the Popup, IFrame, and Redirect navigators. The existing `NavigatorParams` interface was taking on too many parameters that weren't related to the actual `.navigate()` step during sigin/signout. I've split the following settings out of that interface and made them customizable via params passed to the `.signin*()`/`.signout*()` methods:

* `popupWindowFeatures`
* `popupWindowTarget`
* `silentRequestTimeoutInSeconds`
* `redirectMethod`

This PR has some clean up commits, I recommend reviewing 678ef18 in isolation for a clear view of the refactoring for the above settings.

These changes contain one potentially breaking change where the popup's redirect method is no longer customizable and uses the `'replace'` method instead of `'assign'`. This was chosen because in a popup, navigating backwards would load an un-actionable blank page.